### PR TITLE
Switch Logic from Cookies to LocalStorage

### DIFF
--- a/web-sdk.js
+++ b/web-sdk.js
@@ -1839,17 +1839,12 @@
         }
 
         function r() {
-            var e, t, n, i, o = m.document.cookie,
-                r = {};
-            if (!o || "string" != typeof o) return {};
-            o = o.split(/;\s/);
-            for (e = o.length; e--;) try {
-                t = o[e].match(/^([^=]+)(=(.*))?$/);
-                if (!t) continue;
-                n = p(t[1]);
-                i = p(t[3] || "");
-                r[n] = i;
-            } catch (e) { }
+            var n, i, r = {};
+            for (var key in localStorage) try {
+              n = p(key);
+              i = p(localStorage.getItem(key));
+              r[n] = i;
+            } catch (e) {}
             return r;
         }
 
@@ -1876,8 +1871,14 @@
                 i += "; expires=" + o.toGMTString();
             }
             "path" in n && (i += "; path=" + n.path);
+            "domain" in n && (i += "; domain=" + n.domain);
             n.secure && (i += "; secure");
-            m.document.cookie = i;
+            // m.document.cookie = i;
+            if (t) {
+              localStorage.setItem(e, t);
+            } else {
+              localStorage.removeItem(e);
+            }
         }
 
         function u(e, t, n) {

--- a/web-sdk.js
+++ b/web-sdk.js
@@ -1840,9 +1840,9 @@
 
         function r() {
             var n, i, r = {};
-            for (let i = 0; i < localStorage.length; i++) try {
-                const key = localStorage.key(i);
-                const val = localStorage.getItem(key);
+            for (var i = 0; i < localStorage.length; i++) try {
+                var key = localStorage.key(i);
+                var val = localStorage.getItem(key);
                 n = p(key);
                 i = p(val);
                 r[n] = i;
@@ -1876,8 +1876,8 @@
             "domain" in n && (i += "; domain=" + n.domain);
             n.secure && (i += "; secure");
             // m.document.cookie = i;
-            const key = f(e);
-            const val = f(t);
+            var key = f(e);
+            var val = f(t);
 
             if (val) {
                 localStorage.setItem(key, val);

--- a/web-sdk.js
+++ b/web-sdk.js
@@ -1840,11 +1840,13 @@
 
         function r() {
             var n, i, r = {};
-            for (var key in localStorage) try {
-              n = p(key);
-              i = p(localStorage.getItem(key));
-              r[n] = i;
-            } catch (e) {}
+            for (let i = 0; i < localStorage.length; i++) try {
+                const key = localStorage.key(i);
+                const val = localStorage.getItem(key);
+                n = p(key);
+                i = p(val);
+                r[n] = i;
+            } catch (e) { }
             return r;
         }
 
@@ -1874,10 +1876,13 @@
             "domain" in n && (i += "; domain=" + n.domain);
             n.secure && (i += "; secure");
             // m.document.cookie = i;
-            if (t) {
-              localStorage.setItem(e, t);
+            const key = f(e);
+            const val = f(t);
+
+            if (val) {
+                localStorage.setItem(key, val);
             } else {
-              localStorage.removeItem(e);
+                localStorage.removeItem(key);
             }
         }
 


### PR DESCRIPTION
### What
* Switch cookie get/set logic to use localStorage

### Why
* Safari no-longer allows 3rd party cookies by default