### PR TITLE
HOTFIX: Refactor how localStorage is read

### DIFF
--- a/web-sdk.js
+++ b/web-sdk.js
@@ -1840,13 +1840,12 @@
 
         function r() {
             var n, i, r = {};
-            for (var i = 0; i < localStorage.length; i++) try {
-                var key = localStorage.key(i);
+            Object.keys(localStorage).forEach(function(key){
                 var val = localStorage.getItem(key);
                 n = p(key);
                 i = p(val);
                 r[n] = i;
-            } catch (e) { }
+            });
             return r;
         }
 


### PR DESCRIPTION
Noticed issues with Firefox not reading all the localStorage variables, thus changed the way it's done