### PR TITLE
Update SDK to send over stringified error event

### DIFF
--- a/web-sdk.js
+++ b/web-sdk.js
@@ -3706,7 +3706,7 @@
             this.flush();
         };
         i.prototype._onerror = function (e) {
-            this.debug("_error");
+            this.debug("_error: " + JSON.stringify(e));
             this.fire("error", e);
         };
         i.prototype.generate_frame = function (e, t) {


### PR DESCRIPTION
We need to be able to see the actual error that gets triggered for chatters that get disconnected; it doesn't appear to be sending it over otherwise.