### PR TITLE
Update SDK to send over stringified error even Pt. 2

### DIFF
--- a/web-sdk.js
+++ b/web-sdk.js
@@ -3706,7 +3706,7 @@
             this.flush();
         };
         i.prototype._onerror = function (e) {
-            this.debug("_error: " + JSON.stringify(e));
+            this.debug("_error: " + JSON.stringify(e, ["message", "arguments", "type", "name"]));
             this.fire("error", e);
         };
         i.prototype.generate_frame = function (e, t) {


### PR DESCRIPTION
Add arguments to JSON.stringify as we weren't getting proper messages
e.g `_error: {"isTrusted":true}`