### PR TITLE
SL-999: Expose low level sdk messages

### DIFF
--- a/web-sdk.js
+++ b/web-sdk.js
@@ -5429,6 +5429,13 @@
         Xe.init($e, Ee);
         te();
         Te = function (e) {
+          if (window.zendeskOverrides && window.zendeskOverrides.sdkEventTarget) {
+            window.zendeskOverrides.sdkEventTarget.dispatchEvent(
+              new CustomEvent("low_level_message", {
+                detail: e
+              })
+            );
+          }
           (e.path ? Ee.descend(e.path) : Ee).update(e.update);
         };
         be.on("message", Te);

--- a/web-sdk.js
+++ b/web-sdk.js
@@ -5430,6 +5430,8 @@
         te();
         Te = function (e) {
           if (window.zendeskOverrides && window.zendeskOverrides.sdkEventTarget) {
+            // Dispatch an event for all messages "e". We use this to expose "low level"
+            // messages that we otherwise don't have access to.
             window.zendeskOverrides.sdkEventTarget.dispatchEvent(
               new CustomEvent("low_level_message", {
                 detail: e


### PR DESCRIPTION
`chat` hooks into these events and logs the ones we're interested in to datadog.

An example where a visitor has been banned (captured in `chat`):
![image](https://user-images.githubusercontent.com/4810916/90527794-f0f50480-e13f-11ea-8693-c0c508a1b3a1.png)

Will test in `chat` on `dev` before updating `chat` with new version.